### PR TITLE
feat: onupdate/this.on("update") rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,16 @@
 
 module.exports = {
     rules : {
-        "property-ordering" : require("./rules/property-ordering.js")
+        "property-ordering" : require("./rules/property-ordering.js"),
+        onupdate            : require("./rules/onupdate.js"),
     },
 
     configs : {
         svelte : {
             rules : {
-                "@tivac/svelte/property-ordering" : [ 2, {
+                "@tivac/svelte/onupdate" : "warning",
+
+                "@tivac/svelte/property-ordering" : [ "error", {
                     order : [
                         // Static info
                         "immutable",
@@ -40,9 +43,9 @@ module.exports = {
                         "onteardown",
                         "onstate",
                         "onupdate",
-                    ]
-                }]
-            }
-        }
-    }
+                    ],
+                }],
+            },
+        },
+    },
 };

--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ module.exports = {
     configs : {
         svelte : {
             rules : {
-                "@tivac/svelte/onupdate" : "warning",
-
+                "@tivac/svelte/onupdate"          : "warning",
                 "@tivac/svelte/property-ordering" : [ "error", {
                     order : [
                         // Static info

--- a/rules/onupdate.js
+++ b/rules/onupdate.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const getName = require("../utils/get-name.js");
+
+const subscription = `ExportDefaultDeclaration CallExpression[arguments.0.value="update"] [object.type="ThisExpression"][property.name="on"]`;
+
+module.exports = {
+    meta : {
+        docs : {
+            description : `Warn about using onupdate or this.on("update"). You probably want onstate instead`,
+            category    : "Best Practices",
+            recommended : false,
+        },
+        schema  : [],
+        fixable : true,
+    },
+
+    create(context) {
+        return {
+            "ExportDefaultDeclaration > ObjectExpression > Property"(node) {
+                const name = getName(node);
+
+                if(name !== "onupdate") {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    message : `Found onupdate usage. Consider onstate instead`,
+                    fix     : (fixer) => fixer.replaceText(node, "onstate"),
+                });
+            },
+            
+            [subscription](node) {
+                context.report({
+                    node    : node.parent,
+                    message : `Found "update" event usage. Consider "state" event instead`,
+                    fix     : (fixer) => fixer.replaceText(node.parent.arguments[0], `"state"`),
+                });
+            },
+        };
+    },
+};

--- a/rules/property-ordering.js
+++ b/rules/property-ordering.js
@@ -1,10 +1,6 @@
 "use strict";
 
-const utils = require("eslint/lib/util/ast-utils.js");
-
-function getName(node) {
-    return utils.getStaticPropertyName(node) || node.key.name || null;
-}
+const getName = require("../utils/get-name.js");
 
 function compareOrder(order, prev, curr) {
     const pi = order.indexOf(prev);

--- a/rules/tests/onupdate.test.js
+++ b/rules/tests/onupdate.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const { RuleTester } = require("eslint");
+
+const rule = require("../onupdate.js");
+
+const ruleTester = new RuleTester({
+    parserOptions : {
+        ecmaVersion : 2015,
+        sourceType  : "module",
+    },
+});
+
+ruleTester.run("onupdate", rule, {
+    valid : [
+        `export default { onstate() { } };`,
+        `export default { oncreate() { this.on("state", () => { }); } };`,
+    ],
+    
+    invalid : [
+        {
+            code   : `export default { onupdate };`,
+            output : `export default { onstate };`,
+            errors : [{
+                message : "Found onupdate usage. Consider onstate instead",
+            }],
+        },
+        {
+            code   : `export default { oncreate() { this.on("update", () => { }); } };`,
+            output : `export default { oncreate() { this.on("state", () => { }); } };`,
+            errors : [{
+                message : `Found "update" event usage. Consider "state" event instead`,
+            }],
+        },
+    ],
+});

--- a/rules/tests/property-ordering.test.js
+++ b/rules/tests/property-ordering.test.js
@@ -8,8 +8,8 @@ const rule = require("../property-ordering.js");
 const ruleTester = new RuleTester({
     parserOptions : {
         ecmaVersion : 2015,
-        sourceType  : "module"
-    }
+        sourceType  : "module",
+    },
 });
 
 ruleTester.run("property-ordering", rule, {
@@ -23,8 +23,8 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "immutable",
                     "data",
-                ]
-            }]
+                ],
+            }],
         },
 
         {
@@ -36,8 +36,8 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "immutable",
                     "data",
-                ]
-            }]
+                ],
+            }],
         },
         
         {
@@ -49,8 +49,8 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "immutable",
                     "data",
-                ]
-            }]
+                ],
+            }],
         },
 
         {
@@ -64,9 +64,9 @@ ruleTester.run("property-ordering", rule, {
                     "namespace",
                     "components",
                     "data",
-                ]
-            }]
-        }
+                ],
+            }],
+        },
     ],
 
     invalid : [
@@ -76,11 +76,11 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "data",
                     "immutable",
-                ]
+                ],
             }],
             errors : [{
-                message : `Expected object keys to ordered. "data" should come before "immutable".`
-            }]
+                message : `Expected object keys to ordered. "data" should come before "immutable".`,
+            }],
         },
 
         {
@@ -89,11 +89,11 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "data",
                     "immutable",
-                ]
+                ],
             }],
             errors : [{
-                message : `Expected object keys to ordered. "data" should come before "immutable".`
-            }]
+                message : `Expected object keys to ordered. "data" should come before "immutable".`,
+            }],
         },
 
         {
@@ -102,11 +102,11 @@ ruleTester.run("property-ordering", rule, {
                 order : [
                     "data",
                     "immutable",
-                ]
+                ],
             }],
             errors : [{
-                message : `Expected object keys to ordered. "data" should come before "immutable".`
-            }]
+                message : `Expected object keys to ordered. "data" should come before "immutable".`,
+            }],
         },
-    ]
+    ],
 });

--- a/utils/get-name.js
+++ b/utils/get-name.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const utils = require("eslint/lib/util/ast-utils.js");
+
+module.exports = (node) =>
+    utils.getStaticPropertyName(node) || node.key.name || null;


### PR DESCRIPTION
Since `onupdate` or `this.on("update")` are usually not what we want to use I wrote a rule that can warn about 'em and fix them to always use `onstate` or `this.on("state")`. Easy enough to disable using a
```js
// eslint-disable-next-line @tivac/svelte/onupdate
this.on("update", () => ...);
```
pragma for those few times where you do actually want it.