### PR TITLE
feat: Check for this.refs usage inside onstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,119 @@ This plugin provides a shared config named `svelte` which can be used by adding 
 
 ## Rules
 
-- [`property-ordering`](#property-ordering)
+- [`onstate-this-refs`](#onstate-this-refs)
 - [`onupdate`](#onupdate)
+- [`property-ordering`](#property-ordering)
 
 ## Rule Details
+
+### `onstate-this-refs`
+
+This rule warns whenever any code accesses `this.refs` from within a `state` lifecycle hook. Since `onstate` fires [before the DOM has been updated](https://svelte.technology/guide#lifecycle-hooks) it's likely that any DOM elements using a `ref` attribute either don't exist or havne't been updated. Using `onupdate` or `this.on("update")` is usually a better choice..
+
+#### Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint @tivac/svelte/onstate-this-refs: "error" */
+/* eslint-env es6 */
+
+export default {
+    onstate() {
+        // this.refs.foo
+    },
+};
+```
+
+```js
+/* eslint @tivac/svelte/onstate-this-refs: "error" */
+/* eslint-env es6 */
+
+export default {
+    oncreate() {
+        this.on("state", () => {
+            // this.refs.foo
+        });
+    },
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint @tivac/svelte/onstate-this-refs: "error" */
+/* eslint-env es6 */
+
+export default {
+    onupdate() {
+        // this.refs.foo
+    },
+};
+```
+
+```js
+/* eslint @tivac/svelte/onstate-this-refs: "error" */
+/* eslint-env es6 */
+
+export default {
+    oncreate() {
+        this.on("update", () => {
+            // this.refs.foo
+        });
+    },
+};
+```
+
+### `onupdate`
+
+The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+This rule warns whenever you use the `onupdate` lifecycle hook, or use `this.on("update")` to subscribe to the `update` lifecycle event. Since `onupdate` fires [after the DOM has been updated](https://svelte.technology/guide#lifecycle-hooks) it might be what you want but often `onstate` is a better choice.
+
+#### Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint @tivac/svelte/onupdate: "error" */
+/* eslint-env es6 */
+
+export default {
+    onupdate() {
+        // ...
+    },
+};
+
+export default {
+    oncreate() {
+        this.on("update", () => {
+            // ...
+        });
+    },
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint @tivac/svelte/onupdate: "error" */
+/* eslint-env es6 */
+
+export default {
+    onstate() {
+        // ...
+    },
+};
+
+export default {
+    oncreate() {
+        this.on("state", () => {
+            // ...
+        });
+    },
+};
+```
 
 ### `property-ordering`
 
@@ -110,52 +219,4 @@ The 1st option is an object which has 1 property
 
 Any property names which are not in `order` will be ignored, so it's better to be explicit when configuring.
 
-### `onupdate`
 
-The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
-
-This rule warns whenever you use the `onupdate` lifecycle hook, or use `this.on("update")` to subscribe to the `update` lifecycle event. Since `onupdate` fires [after the DOM has been updated](https://svelte.technology/guide#lifecycle-hooks) it might be what you want but often `onstate` is a better choice.
-
-#### Examples
-
-Examples of **incorrect** code for this rule:
-
-```js
-/* eslint @tivac/svelte/onupdate: "error" */
-/* eslint-env es6 */
-
-export default {
-    onupdate() {
-        // ...
-    },
-};
-
-export default {
-    oncreate() {
-        this.on("update", () => {
-            // ...
-        });
-    },
-};
-```
-
-Examples of **correct** code for this rule:
-
-```js
-/* eslint @tivac/svelte/onupdate: "error" */
-/* eslint-env es6 */
-
-export default {
-    onstate() {
-        // ...
-    },
-};
-
-export default {
-    oncreate() {
-        this.on("state", () => {
-            // ...
-        });
-    },
-};
-```

--- a/index.js
+++ b/index.js
@@ -2,14 +2,16 @@
 
 module.exports = {
     rules : {
-        "property-ordering" : require("./rules/property-ordering.js"),
         onupdate            : require("./rules/onupdate.js"),
+        "onstate-this-refs" : require("./rules/onstate-this-refs.js"),
+        "property-ordering" : require("./rules/property-ordering.js"),
     },
 
     configs : {
         svelte : {
             rules : {
                 "@tivac/svelte/onupdate"          : "warning",
+                "@tivac/svelte/onstate-this-refs" : "warning",
                 "@tivac/svelte/property-ordering" : [ "error", {
                     order : [
                         // Static info

--- a/rules/onstate-this-refs.js
+++ b/rules/onstate-this-refs.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const refs = `MemberExpression[object.type=ThisExpression][property.name="refs"]`;
+const property = `ExportDefaultDeclaration Property[key.name="onstate"] ${refs}`;
+const subscription = `ExportDefaultDeclaration CallExpression[arguments.0.value="state"] ${refs}`;
+
+module.exports = {
+    meta : {
+        docs : {
+            description : `Warn about using this.refs in a state update`,
+            category    : "Best Practices",
+            recommended : false,
+        },
+        
+        schema : [],
+
+        messages : {
+            warning : `Avoid using this.refs in onstate or this.on("state"), the DOM isn't updated yet.`,
+        },
+    },
+
+    create(context) {
+        const handler = (node) => {
+            context.report({
+                node,
+                messageId : "warning",
+            });
+        };
+
+        return {
+            [property]     : handler,
+            [subscription] : handler,
+        };
+    },
+};

--- a/rules/tests/onstate-this-refs.test.js
+++ b/rules/tests/onstate-this-refs.test.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const dedent = require("dedent");
+const { RuleTester } = require("eslint");
+
+const rule = require("../onstate-this-refs.js");
+
+const ruleTester = new RuleTester({
+    parserOptions : {
+        ecmaVersion : 2015,
+        sourceType  : "module",
+    },
+});
+
+ruleTester.run("onstate-this-refs", rule, {
+    valid : [
+        dedent(`
+            export default {
+                onupdate() {
+                    this.refs.foo = "a";
+                }
+            };
+        `),
+        dedent(`
+            export default {
+                oncreate() {
+                    this.on("update", () => {
+                        this.refs.foo = "a";
+                    });
+                }
+            };
+        `),
+    ],
+    
+    invalid : [
+        {
+            code : dedent(`
+                export default {
+                    onstate() {
+                        this.refs.foo = "a";
+                    }
+                };
+            `),
+            errors : [{
+                messageId : "warning",
+            }],
+        },
+        {
+            code : dedent(`
+                export default {
+                    oncreate() {
+                        this.on("state", () => {
+                            this.refs.foo = "a";
+                        });
+                    }
+                };
+            `),
+            errors : [{
+                messageId : "warning",
+            }],
+        },
+    ],
+});


### PR DESCRIPTION
Generally it's safer to access `this.refs` inside an `onupdate` block, so warn if it's inside `onstate`.