### PR TITLE
Change warning to warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = {
     configs : {
         svelte : {
             rules : {
-                "@tivac/svelte/onupdate"          : "warning",
-                "@tivac/svelte/onstate-this-refs" : "warning",
+                "@tivac/svelte/onupdate"          : "warn",
+                "@tivac/svelte/onstate-this-refs" : "warn",
                 "@tivac/svelte/property-ordering" : [ "error", {
                     order : [
                         // Static info


### PR DESCRIPTION
```
Error: plugin:@tivac/svelte/svelte:
        Configuration for rule "@tivac/svelte/onupdate" is invalid:
        Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"warning"').
```