### PR TITLE
feat!: derived-inputs-outputs rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
         "reactive-literals"      : require("./rules/reactive-literals.js"),
         "stores-initial-value"   : require("./rules/stores-initial-value.js"),
         "stores-no-async"        : require("./rules/stores-no-async.js"),
+        "derived-inputs-outputs" : require("./rules/derived-inputs-outputs.js"),
     },
 
     configs : {
@@ -19,6 +20,7 @@ module.exports = {
                 "@tivac/svelte/reactive-literals"      : "warn",
                 "@tivac/svelte/stores-initial-value"   : "warn",
                 "@tivac/svelte/stores-no-async"        : "error",
+                "@tivac/svelte/derived-inputs-ouputs"  : "warn",
             },
         },
     },

--- a/rules/derived-inputs-outputs.js
+++ b/rules/derived-inputs-outputs.js
@@ -1,0 +1,93 @@
+"use strict";
+
+module.exports = {
+    meta : {
+        type : "suggestion",
+
+        messages : {
+            storeNames : `Derived store value names should match the inputs, got {{actual}} but expected {{expected}}`,
+            suggestion : `Rename the value to {{expected}} to match the input store`,
+        },
+
+        hasSuggestions : true,
+    },
+
+    create(context) {
+        let source;
+      
+        const check = (sources, values) => {
+            sources.forEach((input, idx) => {
+                const expected = `$${input.name}`;
+                const actual = values[idx].name;
+              
+                if(expected === actual) {
+                    return;
+                }
+            
+                if(!source) {
+                    source = context.getSourceCode();
+                }
+            
+                const tokens = source.getTokens(values[idx]);
+            
+                context.report({
+                    node      : values[idx],
+                    messageId : "storeNames",
+                    data      : {
+                        expected,
+                        actual,
+                    },
+                    suggest : [{
+                        messageId : "suggestion",
+                        data      : { expected },
+                        fix       : (fixer) => fixer.replaceText(tokens[0], expected),
+                    }],
+                });
+            });
+        };
+      
+        return {
+            [`:expression[callee.name="derived"][arguments.0.type="Identifier"]`] : (node) => {
+                const [ input, callback ] = node.arguments;
+              
+                if(callback.params[0].type !== "Identifier") {
+                    return;
+                }
+              
+                check([ input ], [ callback.params[0] ]);
+            },
+          
+            [`:expression[callee.name="derived"][arguments.0.type="ArrayExpression"]`] : (node) => {
+                const [ inputs, callback ] = node.arguments;
+            
+                if(callback.params[0].type !== "ArrayPattern") {
+                    return;
+                }
+            
+                // Collect input store names
+                const sources = [];
+
+                for(const input of inputs.elements) {
+                    if(input.type !== "Identifier") {
+                        return;
+                    }
+
+                    sources.push(input);
+                }
+
+                // Collect output store names
+                const values = [];
+
+                for(const output of callback.params[0].elements) {
+                    if(output.type !== "Identifier") {
+                        return;
+                    }
+
+                    values.push(output);
+                }
+
+                check(sources, values);
+            },
+        };
+    },
+};

--- a/rules/reactive-curlies.js
+++ b/rules/reactive-curlies.js
@@ -2,12 +2,6 @@
 
 module.exports = {
     meta : {
-        docs : {
-            description : "Unnecessary curly braces around reactive statements are unnecessary, don't do it!",
-            category    : "Best Practices",
-            recommended : false,
-        },
-
         messages : {
             unnecessaryCurlies : `Do not wrap reactive statements in curly braces unless necessary.`,
         },

--- a/rules/reactive-destructuring.js
+++ b/rules/reactive-destructuring.js
@@ -6,12 +6,6 @@ module.exports = {
     meta : {
         type : "problem",
 
-        docs : {
-            description : "Prefer destructuring, even in reactive statements",
-            category    : "Best Practices",
-            recommended : false,
-        },
-
         messages : {
             useDestructuring : `Prefer destructuring in reactive statements`,
         },

--- a/rules/reactive-functions.js
+++ b/rules/reactive-functions.js
@@ -2,12 +2,6 @@
 
 module.exports = {
     meta : {
-        docs : {
-            description : "Creating functions inside reactive statements is bad, don't do it",
-            category    : "Best Practices",
-            recommended : false,
-        },
-
         messages : {
             noReactiveFns : `Do not create functions inside reactive statements unless absolutely necessary.`,
         },

--- a/rules/reactive-literals.js
+++ b/rules/reactive-literals.js
@@ -4,12 +4,6 @@ const labeledStatementBase = `LabeledStatement[label.name="$"] > ExpressionState
 
 module.exports = {
     meta : {
-        docs : {
-            description : "Assigning to literal values inside reactive statements is bad, don't do it",
-            category    : "Best Practices",
-            recommended : false,
-        },
-
         messages : {
             noReactiveLiterals : `Do not assign literal values inside reactive statements unless absolutely necessary.`,
         },

--- a/rules/store-prop-destructuring.js
+++ b/rules/store-prop-destructuring.js
@@ -2,13 +2,8 @@
 
 module.exports = {
     meta : {
-        docs : {
-            description : "Destructure properties from stores containing objects for better redraw perf",
-            category    : "Best Practices",
-            recommended : false,
-        },
         messages : {
-            useDestructuring : "Destructure \\{{prop}} from store \\{{store}} for better change tracking",
+            useDestructuring : `Destructure {{prop}} from store {{store}} for better change tracking`,
         },
     },
 

--- a/rules/stores-initial-value.js
+++ b/rules/stores-initial-value.js
@@ -4,12 +4,6 @@ module.exports = {
     meta : {
         type : "problem",
 
-        docs : {
-            description : "Svelte3 stores should always have a default value (ideally false) for destructuring purposes",
-            category    : "Best Practices",
-            recommended : false,
-        },
-
         messages : {
             storeDefaultValue : `Always set a default value of "false" for svelte stores.`,
         },

--- a/rules/stores-no-async.js
+++ b/rules/stores-no-async.js
@@ -2,19 +2,13 @@
 
 module.exports = {
     meta : {
-        type : "problem",
-
-        docs : {
-            description : "Svelte3 store callbacks can't be async, because they expect the returned value to be a function",
-            category    : "Best Practices",
-            recommended : false,
-        },
+        type : "suggestion",
 
         messages : {
             noAsyncStores : `Do not pass async functions to svelte stores.`,
         },
 
-        fixable : "code",
+        hasSuggestions : true,
     },
 
     create(context) {
@@ -34,13 +28,14 @@ module.exports = {
                 loc       : fn.loc,
                 messageId : "noAsyncStores",
 
-                fix : (fixer) => [
-                    // Removes the leading "async " from the function definition
-                    fixer.removeRange([
+                // Remove the leading "async " from the function definition
+                suggest : [{
+                    desc : "Remove the async and use Promise methods instead",
+                    fix  : (fixer) => fixer.removeRange([
                         tokens[0].range[0],
                         tokens[1].range[0],
                     ]),
-                ],
+                }],
             });
         };
 

--- a/tests/_tester.js
+++ b/tests/_tester.js
@@ -2,7 +2,7 @@ const { RuleTester } = require("eslint");
 const { suite } = require("uvu");
 
 module.exports = (name, rule, tests) => {
-    const test = suite("store-prop-destructuring");
+    const test = suite(name);
 
     RuleTester.it = test;
     RuleTester.itOnly = test.only;

--- a/tests/derived-inputs-outputs.test.js
+++ b/tests/derived-inputs-outputs.test.js
@@ -1,0 +1,37 @@
+const rule = require("../rules/derived-inputs-outputs.js");
+const _tester = require("./_tester.js");
+
+_tester("derived-inputs-outputs", rule, {
+    valid : [
+        `derived(a, ($a) => {})`,
+        `derived(a, ($a, set) => {})`,
+        `derived([ a, b ], ([ $a, $b ]) => {})`,
+    ],
+
+    invalid : [{
+        code   : `derived(a, (b) => {});`,
+        errors : [{
+            suggestions : [{
+                output : `derived(a, ($a) => {});`,
+            }],
+        }],
+    }, {
+        code   : `derived(a, (b, set) => {});`,
+        errors : [{
+            suggestions : [{
+                output : `derived(a, ($a, set) => {});`,
+            }],
+        }],
+    }, {
+        code   : `derived([ a, b ], ([ one, two ]) => {})`,
+        errors : [{
+            suggestions : [{
+                output : `derived([ a, b ], ([ $a, two ]) => {})`,
+            }],
+        }, {
+            suggestions : [{
+                output : `derived([ a, b ], ([ one, $b ]) => {})`,
+            }],
+        }],
+    }],
+});

--- a/tests/stores-no-async.test.js
+++ b/tests/stores-no-async.test.js
@@ -10,15 +10,24 @@ _tester("stores-no-async", rule, {
 
     invalid : [{
         code   : `const w = writable(false, async () => {});`,
-        output : `const w = writable(false, () => {});`,
-        errors : [{ messageId : "noAsyncStores" }],
+        errors : [{
+            suggestions : [{
+                output : `const w = writable(false, () => {});`,
+            }],
+        }],
     }, {
         code   : `const r = readable(false, async () => {});`,
-        output : `const r = readable(false, () => {});`,
-        errors : [{ messageId : "noAsyncStores" }],
+        errors : [{
+            suggestions : [{
+                output : `const r = readable(false, () => {});`,
+            }],
+        }],
     }, {
         code   : `const d = derived([a, b], async () => {}, false);`,
-        output : `const d = derived([a, b], () => {}, false);`,
-        errors : [{ messageId : "noAsyncStores" }],
+        errors : [{
+            suggestions : [{
+                output : `const d = derived([a, b], () => {}, false);`,
+            }],
+        }],
     }],
 });


### PR DESCRIPTION
Adding a new rule to ensure that the values passed to the callback of a `derived()` always match the names of the input stores with a `$` prefixed to them.

```js
// Passes
const d = derived([ a, b ], ([ $a, $b ]) => { ... });

// Fails
const d = derived(a, ($value) => { ... });
```

Fixes #24 